### PR TITLE
Add css to make select/dropdown black font color, close #123

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -137,3 +137,8 @@ a {
 .oarc-word.hovered {
     color:#666666!important;
 }
+
+/* for https://github.com/MissionLaunch/clean-slate/issues/123 */
+select {
+  color: #2b3e50;
+}


### PR DESCRIPTION
<img width="622" alt="screen shot 2016-11-17 at 7 45 05 pm" src="https://cloud.githubusercontent.com/assets/7108211/20414036/5b9b2f28-acfe-11e6-8c35-6d6ecb5f902f.png">

Changed the dropdown/select font color to match the nearby input field (`#2b3e50`)