### PR TITLE
Updated Eligibility Checker and Client List

### DIFF
--- a/partners/index.html
+++ b/partners/index.html
@@ -46,8 +46,7 @@
     <div class="thumbnail">
 	
 			<h3>Welcome to the "Arrest/Conviction Record Analyzer"</h3>
-	  =
-                       
+	                   
  <div class="right">
     <div class="thumbnail">
 	       <h2 >Sign In</h2>

--- a/partners/index.html
+++ b/partners/index.html
@@ -79,7 +79,7 @@
                             <span class="icon-bar"></span>
                         </button>
                         <a class="navbar-brand" href="../#/home">
-                            <img src="img/logo.jpg" alt="logo" width="200">
+                            <img src="../img/logo.jpg" alt="logo" width="200">
                         </a>
                     </div>
                     <div id="navbar-content" class="collapse navbar-collapse">

--- a/partners/index.html
+++ b/partners/index.html
@@ -79,7 +79,7 @@
                             <span class="icon-bar"></span>
                         </button>
                         <a class="navbar-brand" href="../#/home">
-                            <img src="../img/logo.jpg" alt="logo" width="200">
+                            <img src="img/logo.jpg" alt="logo" width="200">
                         </a>
                     </div>
                     <div id="navbar-content" class="collapse navbar-collapse">

--- a/partners/js/client/clients.html
+++ b/partners/js/client/clients.html
@@ -9,11 +9,34 @@
 
      <button ui-sref="newClient" class="btn btn-success">Add New Client</button>
                
-<ul>
-    <li ng-repeat="client in clients">
-        {{ client.clientID }} -  {{ client.status }} {{ client.determination }}
-    </li>
-    
-</ul>
+
+    <div style="padding: 2em">
+        <table class="table table-hover table-bordered">
+            <thead>
+                <tr class="info">
+                    <th>
+                        Client ID
+                    </th>
+                    <th>
+                        Status
+                    </th>
+                    <th>
+                        Determination
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr ng-repeat="client in clients">
+                    <td>{{ client.clientID }} 
+                    </td>
+                    <td>{{ client.status }}
+                    </td>
+                    <td>{{ client.determination }}
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
     </div>
 

--- a/partners/partners.js
+++ b/partners/partners.js
@@ -45,14 +45,11 @@
                 }
             };
             
-            
             $rootScope.logOut = function() {
                 ref.unauth();
                 $rootScope.currentUser = null;
                 $state.go('login');
             };
-   
-   
    
         }])
        
@@ -117,6 +114,8 @@
 
 })();
 
+/*
+
 app.controller('MainCtrl', function ($scope) {
     $scope.currentTime = 0;
 })
@@ -156,3 +155,6 @@ app.directive('someVideo', function ($window, $timeout) {
         }
     }
 })
+
+
+*/

--- a/views/home.html
+++ b/views/home.html
@@ -13,7 +13,7 @@
 <div class="row">
   <div class="col-sm-6 col-md-6">
     <div class="thumbnail">
-      <img src="../img/cleanslate2.png" alt="...">
+      <img src="img/cleanslate2.png" alt="...">
       <div class="caption">
         <h2>Should I have my record sealed?</h2>
         <p>Clean Slate can help you determine the best course of action for your history record. In many cases, sealing your record is not only possible, but the best course of action to broaden your future options. Other times, disclosure is the best path to be hired by potential employers. Click below to find where you fit.</p>
@@ -23,7 +23,7 @@
 	</div>
 	<div class="col-sm-6 col-md-6">
 		<div class="thumbnail">
-			<img src="../img/cleanslate1.png" alt="...">
+			<img src="img/cleanslate1.png" alt="...">
 			<div class="caption">
 				<h2>Am I eligible?</h2>
 				<p>Getting in touch with a lawyer can be tedious. Clean Slate is here with our web service to help you determine your eligilbity to have your record sealed. Simply fill out our form to get started.</p>


### PR DESCRIPTION
I've re-written some of the eligibility checker to fix the logic according to the sealing cheat sheet in the Clean Slate slack channel. It's also been updated to have the saved clients stored in a better looking table.
